### PR TITLE
yiifoundation Alert and ArrayHelper helper

### DIFF
--- a/helpers/Alert.php
+++ b/helpers/Alert.php
@@ -70,7 +70,7 @@ class Alert
      */
     public static function alert($content, $htmlOptions = array(), $close = '&times')
     {
-        Arrayhelper::addValue('class', 'alert-box', $htmlOptions);
+        ArrayHelper::addValue('class', 'alert-box', $htmlOptions);
 
         ob_start();
         echo '<div data-alert ' . \CHtml::renderAttributes($htmlOptions) . '>';

--- a/helpers/ArrayHelper.php
+++ b/helpers/ArrayHelper.php
@@ -23,7 +23,7 @@ class ArrayHelper
      * @param array $to the items to copy to.
      * @return array with copied items.
      */
-    public static function copy($names, $from, $to)
+    public static function copy($names, $from, &$to)
     {
         if (is_array($from) && is_array($to)) {
             foreach ($names as $key) {

--- a/helpers/ArrayHelper.php
+++ b/helpers/ArrayHelper.php
@@ -42,16 +42,17 @@ class ArrayHelper
      * @param array $to the items to move to.
      * @return array with moved items.
      */
-    public static function move($names, $from, &$to)
+    public static function move($names, &$from, &$to)
     {
         if (is_array($from) && is_array($to)) {
             foreach ($names as $key) {
                 if (isset($from[$key]) && !isset($to[$key])) {
-                    $to[$key] = static::removeValue($from, $key);
+                    $to[$key] = static::getValue($from, $key);
+                    $moved[$key] = static::removeValue($from, $key);
                 }
             }
         }
-        return $to;
+        return $moved;
     }
 
     /**


### PR DESCRIPTION
1. a typo on alert helper. (Arrayhelper => ArrayHelper)
2. $to arg of copy method of ArrayHelper helper should be passed by reference
3. $from arg of move method of ArrayHelper helper should be passed by reference
4. the logic of move method of ArrayHelper helper would be  better to changed as shown below.
